### PR TITLE
error in case of spellcheck , $meta->meta->info->searchFeedInfo is null

### DIFF
--- a/AFS/SEARCH/afs_metadata_helper.php
+++ b/AFS/SEARCH/afs_metadata_helper.php
@@ -15,7 +15,9 @@ class AfsMetadataHelper {
     }
 
     private function initialize_facets_info($meta) {
-        $this->initialize_facets_info_rec($meta->meta->info->searchFeedInfo->setInfos);
+        if (isset($meta->meta->info->searchFeedInfo)) {
+            $this->initialize_facets_info_rec($meta->meta->info->searchFeedInfo->setInfos);
+        }
     }
 
     private function initialize_facets_info_rec($setInfos) {


### PR DESCRIPTION
I met an error in case of spellcheck in response, see exemple : http://poc-addonline.afs-antidot.net/search?afs:replies=1&afs:what=meta&afs:userId=user_574eec1e88e0d&afs:sessionId=574ec94f9b6dd&afs:log=AFS@Store%20for%20Magento%20v1.2.3&afs:log=Magento%20Community%201.9.2.4&afs:log=Antidot%20PHP%20API%20v0.16.6&afs:log=PHP_VERSION_5.6.19&afs:facetDefault=replies=1000&afs:facetDefault=sort=items&afs:facetDefault=order=DESC&afs:feed=Catalog&afs:feed=Promote&afs:feed=Articles&afs:service=45000&afs:status=sandbox&afs:output=xml&afs:ip=192.168.99.1&afs:userAgent=Mozilla/5.0%20(Macintosh;%20Intel%20Mac%20OS%20X%2010_11_5)%20AppleWebKit/537.36%20(KHTML,%20like%20Gecko)%20Chrome/50.0.2661.102%20Safari/537.36

in the uri=spellcheck:de:Catalog  metadata, there's no afs:searchFeedInfo  bracket 