### PR TITLE
add  get_query_parameters  method on afs_introspection

### DIFF
--- a/AFS/SEARCH/TEST/DATA/introspection_responses.php
+++ b/AFS/SEARCH/TEST/DATA/introspection_responses.php
@@ -101,6 +101,10 @@ define('RESULT_WITH_FACETS_FLAT', '{
         {
           "name": "afs:sort",
           "value": "afs:relevance,DESC;category_level,ASC;category_broader_length,ASC;category_name_length,ASC"
+        },
+        {
+          "name": "afs:storeContract",
+          "value": "instantSearch"
         }
       ],
       "mainCtx": {

--- a/AFS/SEARCH/TEST/introspectionTest.php
+++ b/AFS/SEARCH/TEST/introspectionTest.php
@@ -84,6 +84,13 @@ class IntrospectionTest extends PHPUnit_Framework_TestCase {
     $this->check_facet_info($model, 'model', false, false, 'STRING', 'TREE', $expected_labels);
   }
 
+  public function testInstantSearch() {
+    $introspector = $this->init_introspector(RESULT_WITHOUT_FACETS);
+    $this->assertNotEquals($introspector->get_query_parameter('afs:storeContract'), 'instantSearch');
+    $introspector = $this->init_introspector(RESULT_WITH_FACETS_FLAT);
+    $this->assertEquals($introspector->get_query_parameter('afs:storeContract'), 'instantSearch');
+  }
+
   private function check_facet_info($facet_info, $expected_name, $is_sticky, $is_filter, $expected_type,
                                    $expected_layout, $expected_labels=null)
   {

--- a/AFS/SEARCH/TEST/responseHelperTest.php
+++ b/AFS/SEARCH/TEST/responseHelperTest.php
@@ -606,6 +606,54 @@ class ResponseHelperTest extends PHPUnit_Framework_TestCase
         $this->assertTrue($response_helper->has_metadata('Catalog'));
         $this->assertNotNull($response_helper->get_feed_metadata('Catalog'));
     }
+
+    public function testGetQueryParameter()
+    {
+        $input = json_decode('{
+                "header": {
+                    "query": {
+                        "userId": "foo",
+                        "sessionId": "bar",
+                        "queryParam": [
+                            {
+                              "name": "afs:storeContract",
+                              "value": "instantSearch"
+                            }]
+                    },
+                    "user": { },
+                    "performance": {
+                        "durationMs": 215
+                    },
+                    "info": { }
+                }
+            }');
+
+        $config = new AfsHelperConfiguration();
+        $query = new AfsQuery();
+        $response = new AfsResponseHelper($input, $query, $config);
+        $this->assertEquals($response->get_query_parameter('afs:storeContract'), 'instantSearch');
+
+        $input = json_decode('{
+                "header": {
+                    "query": {
+                        "userId": "foo",
+                        "sessionId": "bar",
+                        "queryParam": []
+                    },
+                    "user": { },
+                    "performance": {
+                        "durationMs": 215
+                    },
+                    "info": { }
+                }
+            }');
+
+        $config = new AfsHelperConfiguration();
+        $query = new AfsQuery();
+        $response = new AfsResponseHelper($input, $query, $config);
+        $this->assertNotEquals($response->get_query_parameter('afs:storeContract'), 'instantSearch');
+
+    }
 }
 
 

--- a/AFS/SEARCH/afs_introspection.php
+++ b/AFS/SEARCH/afs_introspection.php
@@ -8,6 +8,7 @@
  */
 class AfsIntrospection {
     private $feeds_metadata = array();
+    private $result;
 
     public function __construct($search) {
         $this->build_metadata($search);
@@ -47,11 +48,23 @@ class AfsIntrospection {
         }
     }
 
+    /**
+    *@brief Retrieve query parameter stored in header
+    * @input $key : Name of the parameter
+    * @return value of the parameter
+    */
+    public function get_query_parameter($key)
+    {
+        return $this->result->get_query_parameter($key);
+    }
+
     private function build_metadata($search) {
         $params = array('afs:what' => 'meta');
         $query = AfsQuery::create_from_parameters($params);
+        /** @var AfsResponseHelper $result */
         $result = $search->execute($query);
         $this->feeds_metadata = $result->get_all_metadata();
+        $this->result = $result;
     }
 
     private function setup_feeds_filters($search) {


### PR DESCRIPTION
Add an   is_instantSearch method on afs_introspection in order to know if the contract is an instantSearch 

see Guillaume Fesquet <gfesquet@antidot.net>  

Work in progress : the parameters name nd value in the header query params are not yet validated, don't merge now ! 