### PR TITLE
ARRAY format: check has_replyset before using spellcheck_mgr

### DIFF
--- a/AFS/SEARCH/afs_response_helper.php
+++ b/AFS/SEARCH/afs_response_helper.php
@@ -321,10 +321,12 @@ class AfsResponseHelper extends AfsResponseHelperBase
             return array('error' => $this->get_error_msg());
         } else {
             $result = array('duration' => $this->get_duration());
-            if ($this->has_replyset())
+            if ($this->has_replyset()) {
                 $result['replysets'] = $this->get_replysets();
-            if ($this->spellcheck_mgr->has_spellcheck())
-                $result['spellchecks'] = $this->spellcheck_mgr->format();
+                if ($this->spellcheck_mgr->has_spellcheck()) {
+                    $result['spellchecks'] = $this->spellcheck_mgr->format();
+                }
+            }
             return $result;
         }
     }


### PR DESCRIPTION
If no replyset, constructor does not initiate spellcheck_mgr keeping null value.
Always check has_replyset before using spellcheck_mgr in ARRAY format 